### PR TITLE
fix: TCP half-packet causes decoding exception

### DIFF
--- a/runner-core/src/main/java/org/apache/apisix/plugin/runner/codec/DelayedDecoder.java
+++ b/runner-core/src/main/java/org/apache/apisix/plugin/runner/codec/DelayedDecoder.java
@@ -1,0 +1,25 @@
+package org.apache.apisix.plugin.runner.codec;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.LengthFieldBasedFrameDecoder;
+
+public class DelayedDecoder extends LengthFieldBasedFrameDecoder {
+
+    public DelayedDecoder() {
+        super(16777215, 0, 0);
+    }
+
+    @Override
+    protected ByteBuf decode(ChannelHandlerContext ctx, ByteBuf in) {
+        in.readByte();
+        int length = in.readMedium();
+        if (in.readableBytes() < length) {
+            return null;
+        }
+        in.readerIndex(0);
+
+        int readLength = in.readableBytes();
+        return in.retainedSlice(0, readLength);
+    }
+}

--- a/runner-core/src/main/java/org/apache/apisix/plugin/runner/codec/DelayedDecoder.java
+++ b/runner-core/src/main/java/org/apache/apisix/plugin/runner/codec/DelayedDecoder.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.apisix.plugin.runner.codec;
 
 import io.netty.buffer.ByteBuf;

--- a/runner-core/src/main/java/org/apache/apisix/plugin/runner/server/ApplicationRunner.java
+++ b/runner-core/src/main/java/org/apache/apisix/plugin/runner/server/ApplicationRunner.java
@@ -20,6 +20,7 @@ package org.apache.apisix.plugin.runner.server;
 import io.netty.channel.unix.DomainSocketAddress;
 import io.netty.handler.logging.LoggingHandler;
 import lombok.RequiredArgsConstructor;
+import org.apache.apisix.plugin.runner.codec.DelayedDecoder;
 import org.apache.apisix.plugin.runner.handler.IOHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -64,7 +65,8 @@ public class ApplicationRunner implements CommandLineRunner {
 //            if (Objects.nonNull(channelHandlers)) {
 //                channel.pipeline().addLast(channelHandlers);
 //            }
-            channel.pipeline().addFirst("logger", new LoggingHandler());
+            channel.pipeline().addFirst("logger", new LoggingHandler())
+                    .addAfter("logger", "delayedDecoder", new DelayedDecoder());
         });
 
         if (Objects.nonNull(handler)) {


### PR DESCRIPTION
In some extreme scenarios, netty's guess() function incorrectly predicts the size of the next request and allocates a buffer that is too small, causing the request to be truncated and decoding to fail.
Increased judgment and delay handling.