### PR TITLE
docs: remove duplicate title

### DIFF
--- a/docs/en/latest/the-internal-of-apisix-java-plugin-runner.md
+++ b/docs/en/latest/the-internal-of-apisix-java-plugin-runner.md
@@ -21,6 +21,7 @@ title: The internal of apisix java plugin runner
 #
 -->
 
+
 This article explains the internal design of apisix-java-plugin-runner.
 
 ## Table of Contents

--- a/docs/en/latest/the-internal-of-apisix-java-plugin-runner.md
+++ b/docs/en/latest/the-internal-of-apisix-java-plugin-runner.md
@@ -21,8 +21,6 @@ title: The internal of apisix java plugin runner
 #
 -->
 
-## Overview
-
 This article explains the internal design of apisix-java-plugin-runner.
 
 ## Table of Contents


### PR DESCRIPTION
As the title "overview" entered twice, the link [overview](https://apisix.apache.org/docs/java-plugin-runner/the-internal-of-apisix-java-plugin-runner#overview) isn't directed to correct id.
I think removing first one will be fixed this.

fix: #40 