### PR TITLE
fix: support chinese encoding in the response body

### DIFF
--- a/runner-plugin-sdk/src/main/java/org/apache/apisix/plugin/runner/HttpResponse.java
+++ b/runner-plugin-sdk/src/main/java/org/apache/apisix/plugin/runner/HttpResponse.java
@@ -187,7 +187,7 @@ public class HttpResponse implements A6Response {
 
         int bodyIndex = -1;
         if (StringUtils.hasText(body)) {
-            byte[] bodyBytes = body.getBytes(StandardCharsets.US_ASCII);
+            byte[] bodyBytes = body.getBytes(StandardCharsets.UTF_8);
             bodyIndex = Stop.createBodyVector(builder, bodyBytes);
         }
 


### PR DESCRIPTION
Please answer these questions before submitting a pull request

- Why submit this pull request?
- [ ] Bugfix
- [ ] New feature provided
- [ ] Improve performance

- Related issues

___
### Bugfix
- Description
response.setStatusCode(503);
response.setHeader("Content-Encoding","UTF-8");
response.setHeader("Content-Type","application/json;charset=UTF-8");
response.setHeader("X-GATEWAY-ERROR-FLAG","error");
response.setBody("错误!!!,aaa");

actual result:??!!!,aaa
expected result:错误!!!,aaa
- How to fix?
byte[] bodyBytes = body.getBytes(StandardCharsets.UTF_8);
___
### New feature or improvement
- Describe the details and related test reports.

- Source branch

- Related commits and pull requests

- Target branch
