### PR TITLE
fix: modify socket file permissions so that APISIX has permission to read and write

### DIFF
--- a/runner-core/src/main/java/org/apache/apisix/plugin/runner/server/ApplicationRunner.java
+++ b/runner-core/src/main/java/org/apache/apisix/plugin/runner/server/ApplicationRunner.java
@@ -83,5 +83,6 @@ public class ApplicationRunner implements CommandLineRunner {
         awaitThread.setDaemon(false);
         awaitThread.setName("uds-server");
         awaitThread.start();
+        Runtime.getRuntime().exec("chmod 777 " + socketFile);
     }
 }


### PR DESCRIPTION
Please answer these questions before submitting a pull request

- Why submit this pull request?
- Bugfix

- Related issues
bug message:
![0d09c63ae9c8a6253dbb3bc98045426](https://user-images.githubusercontent.com/33853061/145402821-85045bf3-ea31-4dd3-a7b2-2a726771d711.png)

now message:
![image](https://user-images.githubusercontent.com/33853061/145402957-4eeaf042-9666-4d3a-8310-c16c4f166428.png)

___
### Bugfix
- Description
- apisix java plugin runing sock file no permission

- How to fix?
- apisix java plugin starting end modify sock auth permission
___
### New feature or improvement
- Describe the details and related test reports.

- Source branch
- main

- Related commits and pull requests

- Target branch
- main
