### PR TITLE
fix: disable null as key of req/resp headers and args

### DIFF
--- a/runner-core/src/test/java/org/apache/apisix/plugin/runner/codec/impl/PayloadEncoderTest.java
+++ b/runner-core/src/test/java/org/apache/apisix/plugin/runner/codec/impl/PayloadEncoderTest.java
@@ -287,7 +287,6 @@ class PayloadEncoderTest {
         }
     }
 
-
     @Test
     @DisplayName("test set the parameter of the rewrite request to null")
     void testHttpResponseNPE() {
@@ -298,7 +297,7 @@ class PayloadEncoderTest {
         httpResponse.setHeader(null, null);
         HashMap<String, String> reqHeaders = (HashMap<String, String>) ReflectionTestUtils.getField(httpResponse, "reqHeaders");
         HashMap<String, String> args = (HashMap<String, String>) ReflectionTestUtils.getField(httpResponse, "args");
-        HashMap<String,String> respHeaders = (HashMap<String, String>) ReflectionTestUtils.getField(httpResponse, "respHeaders");
+        HashMap<String, String> respHeaders = (HashMap<String, String>) ReflectionTestUtils.getField(httpResponse, "respHeaders");
         Assertions.assertNull(reqHeaders);
         Assertions.assertNull(args);
         Assertions.assertNull(respHeaders);

--- a/runner-core/src/test/java/org/apache/apisix/plugin/runner/codec/impl/PayloadEncoderTest.java
+++ b/runner-core/src/test/java/org/apache/apisix/plugin/runner/codec/impl/PayloadEncoderTest.java
@@ -33,6 +33,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.nio.ByteBuffer;
+import java.util.HashMap;
 
 @DisplayName("test encode data")
 class PayloadEncoderTest {
@@ -284,5 +285,22 @@ class PayloadEncoderTest {
                 Assertions.assertEquals(stop.headers(i).value(), "Bar");
             }
         }
+    }
+
+
+    @Test
+    @DisplayName("test set the parameter of the rewrite request to null")
+    void testHttpResponseNPE() {
+        HttpResponse httpResponse = new HttpResponse(0L);
+        // HashMap accepts null as key and value, but we want to disable null as key
+        httpResponse.setArg(null, null);
+        httpResponse.setReqHeader(null, null);
+        httpResponse.setHeader(null, null);
+        HashMap<String, String> reqHeaders = (HashMap<String, String>) ReflectionTestUtils.getField(httpResponse, "reqHeaders");
+        HashMap<String, String> args = (HashMap<String, String>) ReflectionTestUtils.getField(httpResponse, "args");
+        HashMap<String,String> respHeaders = (HashMap<String, String>) ReflectionTestUtils.getField(httpResponse, "respHeaders");
+        Assertions.assertNull(reqHeaders);
+        Assertions.assertNull(args);
+        Assertions.assertNull(respHeaders);
     }
 }

--- a/runner-plugin-sdk/src/main/java/org/apache/apisix/plugin/runner/HttpResponse.java
+++ b/runner-plugin-sdk/src/main/java/org/apache/apisix/plugin/runner/HttpResponse.java
@@ -67,6 +67,12 @@ public class HttpResponse implements A6Response {
     }
 
     public void setReqHeader(String headerKey, String headerValue) {
+        // key is null will cause the request to block
+        if (headerKey == null) {
+            logger.warn("headerKey is null, ignore it");
+            return;
+        }
+
         actionType = ActionType.Rewrite;
         if (Objects.isNull(reqHeaders)) {
             reqHeaders = new HashMap<>();
@@ -81,6 +87,10 @@ public class HttpResponse implements A6Response {
      * @param argValue the arg value
      */
     public void setArg(String argKey, String argValue) {
+        if (argKey == null) {
+            logger.warn("argKey is null, ignore it");
+            return;
+        }
         actionType = ActionType.Rewrite;
         if (Objects.isNull(args)) {
             args = new HashMap<>();
@@ -94,6 +104,11 @@ public class HttpResponse implements A6Response {
      * @param path the path
      */
     public void setPath(String path) {
+        if (path == null) {
+            logger.warn("path is empty, ignore it");
+            return;
+        }
+
         actionType = ActionType.Rewrite;
         this.path = path;
     }
@@ -105,6 +120,11 @@ public class HttpResponse implements A6Response {
      * @param headerValue the header value
      */
     public void setHeader(String headerKey, String headerValue) {
+        if (headerKey == null) {
+            logger.warn("headerKey is null, ignore it");
+            return;
+        }
+
         actionType = ActionType.Stop;
         if (Objects.isNull(respHeaders)) {
             respHeaders = new HashMap<>();
@@ -118,6 +138,10 @@ public class HttpResponse implements A6Response {
      * @param body the body(string)
      */
     public void setBody(String body) {
+        if (body == null) {
+            logger.warn("body is null, ignore it");
+            return;
+        }
         actionType = ActionType.Stop;
         this.body = body;
     }

--- a/runner-plugin-sdk/src/main/java/org/apache/apisix/plugin/runner/HttpResponse.java
+++ b/runner-plugin-sdk/src/main/java/org/apache/apisix/plugin/runner/HttpResponse.java
@@ -104,11 +104,6 @@ public class HttpResponse implements A6Response {
      * @param path the path
      */
     public void setPath(String path) {
-        if (path == null) {
-            logger.warn("path is empty, ignore it");
-            return;
-        }
-
         actionType = ActionType.Rewrite;
         this.path = path;
     }
@@ -138,10 +133,6 @@ public class HttpResponse implements A6Response {
      * @param body the body(string)
      */
     public void setBody(String body) {
-        if (body == null) {
-            logger.warn("body is null, ignore it");
-            return;
-        }
         actionType = ActionType.Stop;
         this.body = body;
     }


### PR DESCRIPTION
Signed-off-by: tzssangglass <tzssangglass@gmail.com>

Please answer these questions before submitting a pull request

- Why submit this pull request?
- [x] Bugfix
- [ ] New feature provided
- [ ] Improve performance

- Related issues

___
### Bugfix
- Description

When the key of the following three functions is set to null, the request will block

```
        httpResponse.setArg(null, null);
        httpResponse.setReqHeader(null, null);
        httpResponse.setHeader(null, null);
```

- How to fix?

Add a judgement to stop this abnormal behaviour.
___
### New feature or improvement
- Describe the details and related test reports.

- Source branch

- Related commits and pull requests

- Target branch
