### PR TITLE
feat: catching exceptions thrown during the writeAndFlush

### DIFF
--- a/runner-core/src/main/java/org/apache/apisix/plugin/runner/handler/ExceptionCaughtHandler.java
+++ b/runner-core/src/main/java/org/apache/apisix/plugin/runner/handler/ExceptionCaughtHandler.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.apisix.plugin.runner.handler;
+
+import io.github.api7.A6.Err.Code;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import org.apache.apisix.plugin.runner.A6ErrResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ExceptionCaughtHandler extends ChannelInboundHandlerAdapter {
+    private final Logger logger = LoggerFactory.getLogger(ExceptionCaughtHandler.class);
+
+    @Override
+    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
+        logger.error("handle request error: ", cause);
+        A6ErrResponse errResponse = new A6ErrResponse(Code.SERVICE_UNAVAILABLE);
+        ctx.writeAndFlush(errResponse);
+    }
+}

--- a/runner-core/src/main/java/org/apache/apisix/plugin/runner/handler/HTTPReqCallHandler.java
+++ b/runner-core/src/main/java/org/apache/apisix/plugin/runner/handler/HTTPReqCallHandler.java
@@ -28,6 +28,8 @@ import java.util.Set;
 
 import com.google.common.cache.Cache;
 import io.github.api7.A6.Err.Code;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.SimpleChannelInboundHandler;
 import org.slf4j.Logger;
@@ -118,7 +120,9 @@ public class HTTPReqCallHandler extends SimpleChannelInboundHandler<A6Request> {
         PluginFilterChain chain = conf.getChain();
         chain.filter(currReq, currResp);
 
-        ctx.writeAndFlush(currResp);
+        ChannelFuture future = ctx.writeAndFlush(currResp);
+        future.addListeners(ChannelFutureListener.FIRE_EXCEPTION_ON_FAILURE);
+
     }
 
     private void handleHttpReqCall(ChannelHandlerContext ctx, HttpRequest request) {
@@ -140,7 +144,8 @@ public class HTTPReqCallHandler extends SimpleChannelInboundHandler<A6Request> {
 
         // if the filter chain is empty, then return the response directly
         if (Objects.isNull(chain) || 0 == chain.getFilters().size()) {
-            ctx.writeAndFlush(currResp);
+            ChannelFuture future = ctx.writeAndFlush(currResp);
+            future.addListeners(ChannelFutureListener.FIRE_EXCEPTION_ON_FAILURE);
             return;
         }
 
@@ -170,7 +175,8 @@ public class HTTPReqCallHandler extends SimpleChannelInboundHandler<A6Request> {
                     return;
                 }
                 ExtraInfoRequest extraInfoRequest = new ExtraInfoRequest(varKey, null);
-                ctx.writeAndFlush(extraInfoRequest);
+                ChannelFuture future = ctx.writeAndFlush(currResp);
+                future.addListeners(ChannelFutureListener.FIRE_EXCEPTION_ON_FAILURE);
             }
         }
 
@@ -178,7 +184,8 @@ public class HTTPReqCallHandler extends SimpleChannelInboundHandler<A6Request> {
         if (requiredBody) {
             queue.offer(EXTRA_INFO_REQ_BODY_KEY);
             ExtraInfoRequest extraInfoRequest = new ExtraInfoRequest(null, true);
-            ctx.writeAndFlush(extraInfoRequest);
+            ChannelFuture future = ctx.writeAndFlush(currResp);
+            future.addListeners(ChannelFutureListener.FIRE_EXCEPTION_ON_FAILURE);
         }
 
         // no need to fetch the nginx variables or request body, just do filter

--- a/runner-core/src/main/java/org/apache/apisix/plugin/runner/handler/HTTPReqCallHandler.java
+++ b/runner-core/src/main/java/org/apache/apisix/plugin/runner/handler/HTTPReqCallHandler.java
@@ -175,7 +175,7 @@ public class HTTPReqCallHandler extends SimpleChannelInboundHandler<A6Request> {
                     return;
                 }
                 ExtraInfoRequest extraInfoRequest = new ExtraInfoRequest(varKey, null);
-                ChannelFuture future = ctx.writeAndFlush(currResp);
+                ChannelFuture future = ctx.writeAndFlush(extraInfoRequest);
                 future.addListeners(ChannelFutureListener.FIRE_EXCEPTION_ON_FAILURE);
             }
         }
@@ -184,7 +184,7 @@ public class HTTPReqCallHandler extends SimpleChannelInboundHandler<A6Request> {
         if (requiredBody) {
             queue.offer(EXTRA_INFO_REQ_BODY_KEY);
             ExtraInfoRequest extraInfoRequest = new ExtraInfoRequest(null, true);
-            ChannelFuture future = ctx.writeAndFlush(currResp);
+            ChannelFuture future = ctx.writeAndFlush(extraInfoRequest);
             future.addListeners(ChannelFutureListener.FIRE_EXCEPTION_ON_FAILURE);
         }
 

--- a/runner-core/src/main/java/org/apache/apisix/plugin/runner/server/ApplicationRunner.java
+++ b/runner-core/src/main/java/org/apache/apisix/plugin/runner/server/ApplicationRunner.java
@@ -17,6 +17,21 @@
 
 package org.apache.apisix.plugin.runner.server;
 
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.stereotype.Component;
 import com.google.common.cache.Cache;
 import io.netty.bootstrap.ServerBootstrap;
 import io.netty.channel.ChannelFuture;
@@ -39,21 +54,7 @@ import org.apache.apisix.plugin.runner.handler.HTTPReqCallHandler;
 import org.apache.apisix.plugin.runner.handler.PayloadDecoder;
 import org.apache.apisix.plugin.runner.handler.BinaryProtocolDecoder;
 import org.apache.apisix.plugin.runner.handler.PayloadEncoder;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.ObjectProvider;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.CommandLineRunner;
-import org.springframework.stereotype.Component;
-
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
+import org.apache.apisix.plugin.runner.handler.ExceptionCaughtHandler;
 
 @Component
 @RequiredArgsConstructor
@@ -123,7 +124,8 @@ public class ApplicationRunner implements CommandLineRunner {
                         .addAfter("payloadEncoder", "delayedDecoder", new BinaryProtocolDecoder())
                         .addLast("payloadDecoder", new PayloadDecoder())
                         .addAfter("payloadDecoder", "prepareConfHandler", createConfigReqHandler(cache, beanProvider))
-                        .addAfter("prepareConfHandler", "hTTPReqCallHandler", createA6HttpHandler(cache));
+                        .addAfter("prepareConfHandler", "hTTPReqCallHandler", createA6HttpHandler(cache))
+                        .addLast("exceptionCaughtHandler", new ExceptionCaughtHandler());
 
             }
         });

--- a/runner-core/src/test/java/org/apache/apisix/plugin/runner/handler/A6HttpCallHandlerTest.java
+++ b/runner-core/src/test/java/org/apache/apisix/plugin/runner/handler/A6HttpCallHandlerTest.java
@@ -289,6 +289,4 @@ class A6HttpCallHandlerTest {
                 io.github.api7.A6.HTTPReqCall.Resp.getRootAsResp(response.encode());
         Assertions.assertEquals(resp.actionType(), Action.Stop);
     }
-
-    //TODO add test cases about fetch nginx vars and request body
 }


### PR DESCRIPTION
Signed-off-by: tzssangglass <tzssangglass@gmail.com>

Please answer these questions before submitting a pull request

- Why submit this pull request?
- [ ] Bugfix
- [ ] New feature provided
- [ ] Improve performance

- Related issues

___
### Bugfix
- Description

- How to fix?

___
### New feature or improvement
- Describe the details and related test reports.

Add a ChannelFutureListener and a custom ExceptionCaughtHandler to catch exceptions that may be thrown during the writeAndFlush phase to prevent them from being swallowed.

refer to: https://github.com/apache/apisix-java-plugin-runner/blob/3da21b98fc435dc239af6f1d8a9ceebdd6f1686f/runner-plugin-sdk/src/main/java/org/apache/apisix/plugin/runner/HttpResponse.java#L70

- Source branch

- Related commits and pull requests

- Target branch
