### PR TITLE
chore(e2e): update apisix image to dev

### DIFF
--- a/ci/docker-compose.yml
+++ b/ci/docker-compose.yml
@@ -19,7 +19,7 @@ version: "3"
 
 services:
   apisix:
-    image: apache/apisix:2.12.0-alpine
+    image: apache/apisix:dev
     restart: always
     volumes:
       - ./apisix/config.yaml:/usr/local/apisix/conf/config.yaml:ro


### PR DESCRIPTION
update e2e image to dev, to ensure that new functions can be linked in time.
