### PR TITLE
feat: support deploy jar to the Maven Central repository

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,6 +24,17 @@
     <artifactId>apisix-plugin-runner</artifactId>
     <version>0.2.0</version>
 
+    <distributionManagement>
+        <snapshotRepository>
+            <id>ossrh</id>
+            <url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>
+        </snapshotRepository>
+        <repository>
+            <id>ossrh</id>
+            <url>https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+        </repository>
+    </distributionManagement>
+  
     <parent>
         <groupId>org.apache</groupId>
         <artifactId>apache</artifactId>
@@ -74,6 +85,13 @@
 
     <dependencyManagement>
         <dependencies>
+            <dependency>
+                <groupId>org.sonatype.oss</groupId>
+                <artifactId>oss-parent</artifactId>
+                <version>9</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
             <dependency>
                 <groupId>org.apache.logging.log4j</groupId>
                 <artifactId>log4j-bom</artifactId>
@@ -150,6 +168,57 @@
                         <phase>process-sources</phase>
                         <goals>
                             <goal>check</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-release-plugin</artifactId>
+                <version>3.0.0-M6</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-gpg-plugin</artifactId>
+                <version>1.5</version>
+                <executions>
+                    <execution>
+                        <id>sign-artifacts</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>sign</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <configuration>
+                    <failOnError>false</failOnError>
+                    <additionalparam>-Xdoclint:none</additionalparam>
+                    <source>8</source>
+                </configuration>
+                <version>2.9.1</version>
+                <executions>
+                    <execution>
+                        <id>attach-javadocs</id>
+                        <goals>
+                            <goal>javadoc</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <version>2.2.1</version>
+                <executions>
+                    <execution>
+                        <id>validate</id>
+                        <phase>process-sources</phase>
+                        <goals>
+                            <goal>jar-no-fork</goal>
                         </goals>
                     </execution>
                 </executions>


### PR DESCRIPTION
Note: this is an updated version of a previously closed PR (https://github.com/apache/apisix-java-plugin-runner/pull/153) that I cluttered with poor commits. Apologies for cluttering the list of Closed PRs.

- Why submit this pull request?
- [ ] Bugfix
- [x] New feature provided
- [ ] Improve performance

### New feature or improvement
Updated pom.xml files to allow deployment of JAR to Maven Central Repository. This will allow users to download the JAR from the Maven Repository and build their plugins without having to clone the source code.

I have deployed a test JAR to Maven Central (https://search.maven.org/search?q=io.github.ericluoliu) under my GAV coordinates, and I have used this JAR by referencing it as a dependency in pom.xml to build a functional (end-to-end) demo plugin in a new Java SpringBoot project.

-Source branch: deployJAR branch on https://github.com/ericluoliu/apisix-java-plugin-runner

-Related commits and pull requests: N/A

-Target branch: main branch on https://github.com/apache/apisix-java-plugin-runner