### PR TITLE
ci: update Check License Header

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,9 +37,7 @@ jobs:
           distribution: 'zulu'
           java-version: '11'
       - name: Check License Header
-        uses: apache/skywalking-eyes@main
-        env:
-           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: apache/skywalking-eyes/header@501a28d2fb4a9b962661987e50cf0219631b32ff
       - name: 'Install & Test'
         run: mvn clean install -Dgpg.skip=true
 


### PR DESCRIPTION
We have a dedicate GitHub actions for header check so this should be updated, and we don't recommend using `@main` so there is no unexpected behaviors when we have changes in our codebase.

See https://github.com/apache/skywalking-eyes/pull/123