### PR TITLE
fix: hot reloading not working when java plugin runner is started from different working directory

### DIFF
--- a/runner-starter/src/main/java/org/apache/apisix/plugin/runner/HotReloadProcess.java
+++ b/runner-starter/src/main/java/org/apache/apisix/plugin/runner/HotReloadProcess.java
@@ -108,12 +108,13 @@ public class HotReloadProcess implements ApplicationContextAware {
 
         final BeanDefinitionRegistry registry = (BeanDefinitionRegistry) ctx.getAutowireCapableBeanFactory();
         String userDir = System.getProperty("user.dir");
+        userDir = userDir.substring(0, userDir.lastIndexOf("apisix-java-plugin-runner") + 25);
         String workDir = userDir + loadPath;
 
         Path path = Paths.get(workDir);
         boolean exists = Files.exists(path);
         if (!exists) {
-            logger.warn("The filter workdir fot hot reload {} not exists", workDir);
+            logger.warn("The filter workdir for hot reload {} not exists", workDir);
             cancelHotReload("hotReloadFilter");
             return;
         }


### PR DESCRIPTION
___
### Bugfix
- Description: when user runs apisix-java-plugin-runner from a different working directory than the root project, the *userDir* variable is incorrect. For example, if user uses command 

java -jar -DAPISIX_LISTEN_ADDRESS=unix:/tmp/runner.sock -DAPISIX_CONF_EXPIRE_TIME=3600 apisix-java-plugin-runner.jar

to start apisix from within the runner-starter/target/ directory, the working directory is different. This causes hot reloading to fail because the path to the filters also is incorrect.


- How to fix? Instead of using the working directory, use the absolute path to the root of the project instead.
