### PR TITLE
fix: remove unnecessary classloader instantiation in main method

### DIFF
--- a/runner-starter/src/main/java/org/apache/apisix/plugin/runner/PluginRunnerApplication.java
+++ b/runner-starter/src/main/java/org/apache/apisix/plugin/runner/PluginRunnerApplication.java
@@ -25,8 +25,6 @@ import org.springframework.scheduling.annotation.ScheduledAnnotationBeanPostProc
 
 @SpringBootApplication
 public class PluginRunnerApplication {
-    private static ClassLoader PARENT_CLASS_LOADER;
-    private static DynamicClassLoader CLASS_LOADER;
 
     @Bean
     public ScheduledAnnotationBeanPostProcessor processor() {
@@ -35,10 +33,6 @@ public class PluginRunnerApplication {
 
     public static void main(String[] args) {
 
-        //load specified classes using dynamic class loader
-        PARENT_CLASS_LOADER = DynamicClassLoader.class.getClassLoader();
-        CLASS_LOADER = new DynamicClassLoader(PARENT_CLASS_LOADER);
-        Thread.currentThread().setContextClassLoader(CLASS_LOADER);
         new SpringApplicationBuilder(PluginRunnerApplication.class)
                 .web(WebApplicationType.NONE)
                 .run(args);


### PR DESCRIPTION
### Improvement
Remove unnecessary lines. Dynamic class loader still supports hot reloading (because Spring beans are reloaded). 

Setting the Spring Boot ClassLoader using *.setContextClassLoader()* does not actually change how plugins and BOOT-INF/ files are loaded. The actual application classes are still loaded by *LaunchedUrlClassLoader* https://docs.spring.io/spring-boot/docs/1.2.x-SNAPSHOT/api/org/springframework/boot/loader/LaunchedURLClassLoader.html. The Spring Boot *JarLauncher* (that launches the SpringBoot application) uses *LaunchedUrlClassLoader*
