### PR TITLE
docs: fix file name

### DIFF
--- a/docs/en/latest/config.json
+++ b/docs/en/latest/config.json
@@ -23,7 +23,7 @@
       },
       {
         "type": "doc",
-        "id": "hot-reload"
+        "id": "hot-reloading"
       }
     ]
   }


### PR DESCRIPTION
When the file name was updated, it wasn't changed in the config.json file causing the documentation build to fail.

We might need to setup deploy previews for these repos as well or do some static analysis. These issues are easy to miss. I only noticed it because I resynced my local apisix-website repo to work on some separate docs and the build failed.

![Screenshot 2022-08-15 at 8 50 29 AM](https://user-images.githubusercontent.com/49474499/184571853-ae7bbef2-c09e-4cbc-b202-6b6979d9cab8.png)