### PR TITLE
feat: `PostResponse` supports charset other than `UTF-8`

### DIFF
--- a/runner-plugin-sdk/pom.xml
+++ b/runner-plugin-sdk/pom.xml
@@ -60,5 +60,10 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/runner-plugin-sdk/src/main/java/org/apache/apisix/plugin/runner/PostResponse.java
+++ b/runner-plugin-sdk/src/main/java/org/apache/apisix/plugin/runner/PostResponse.java
@@ -57,7 +57,7 @@ public class PostResponse implements A6Response {
 
         int bodyIndex = -1;
         if (StringUtils.hasText(body)) {
-            byte[] bodyBytes = body.getBytes(charset);
+            byte[] bodyBytes = body.getBytes(this.charset);
             bodyIndex = Resp.createBodyVector(builder, bodyBytes);
         }
 

--- a/runner-plugin-sdk/src/main/java/org/apache/apisix/plugin/runner/PostResponse.java
+++ b/runner-plugin-sdk/src/main/java/org/apache/apisix/plugin/runner/PostResponse.java
@@ -26,6 +26,7 @@ import org.springframework.util.CollectionUtils;
 import org.springframework.util.StringUtils;
 
 import java.nio.ByteBuffer;
+import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
@@ -43,8 +44,11 @@ public class PostResponse implements A6Response {
 
     private Map<String, String> headers;
 
+    private Charset charset;
+
     public PostResponse(long requestId) {
         this.requestId = requestId;
+        this.charset = StandardCharsets.UTF_8;
     }
 
     @Override
@@ -53,7 +57,7 @@ public class PostResponse implements A6Response {
 
         int bodyIndex = -1;
         if (StringUtils.hasText(body)) {
-            byte[] bodyBytes = body.getBytes(StandardCharsets.UTF_8);
+            byte[] bodyBytes = body.getBytes(charset);
             bodyIndex = Resp.createBodyVector(builder, bodyBytes);
         }
 
@@ -121,5 +125,9 @@ public class PostResponse implements A6Response {
 
     public void setStatusCode(int statusCode) {
         this.statusCode = statusCode;
+    }
+
+    public void setCharset(Charset charset) {
+        this.charset = charset;
     }
 }

--- a/runner-plugin-sdk/src/test/java/org/apache/apisix/plugin/runner/PostResponseTest.java
+++ b/runner-plugin-sdk/src/test/java/org/apache/apisix/plugin/runner/PostResponseTest.java
@@ -1,0 +1,55 @@
+package org.apache.apisix.plugin.runner;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class PostResponseTest {
+
+    @Test
+    @DisplayName("test encode with set charset")
+    void testEncodeWithSetCharset() {
+        long requestId = 1L;
+        String body = "dummy body";
+        Charset charset = StandardCharsets.UTF_16;
+
+        PostResponse postResponse = new PostResponse(requestId);
+        postResponse.setBody(body);
+        postResponse.setCharset(charset);
+
+        ByteBuffer encoded = postResponse.encode();
+
+        assertTrue(Collections.indexOfSubList(byteArrayToList(encoded.array()), byteArrayToList(body.getBytes(charset))) >= 0);
+    }
+
+    @Test
+    @DisplayName("test encode without set charset")
+    void testEncodeWithoutSetCharset() {
+        long requestId = 1L;
+        String body = "dummy body";
+        Charset charset = StandardCharsets.UTF_8;
+
+        PostResponse postResponse = new PostResponse(requestId);
+        postResponse.setBody(body);
+
+        ByteBuffer encoded = postResponse.encode();
+
+        assertTrue(Collections.indexOfSubList(byteArrayToList(encoded.array()), byteArrayToList(body.getBytes(charset))) >= 0);
+    }
+
+    private List<Byte> byteArrayToList(byte[] array) {
+        List<Byte> list = new ArrayList<>();
+        for (byte b : array) {
+            list.add(b);
+        }
+        return list;
+    }
+}


### PR DESCRIPTION
Please answer these questions before submitting a pull request

- Why submit this pull request?
- [ ] Bugfix
- [x] New feature provided
- [ ] Improve performance

- Related issues
#238 
___
### Bugfix
- Description

- How to fix?

___
### New feature or improvement
- Describe the details and related test reports.
`PostResponse` by default converts the body to bytes in `UTF-8`.
It would be nice to support other charsets.

- Source branch
main

- Related commits and pull requests

- Target branch
main