### PR TITLE
chore: update CI runs on ubuntu-latest

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,7 +26,7 @@ on:
 
 jobs:
   CI:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     timeout-minutes: 180
     strategy:
       fail-fast: true


### PR DESCRIPTION
Please answer these questions before submitting a pull request

- Why submit this pull request?
- [ ] Bugfix
- [ ] New feature provided
- [ ] Improve performance

Fix PR #239, CI always wait for actions runner.  But the Ubuntu 18.04 Actions runner image is being deprecated and will be removed by 12/1/22

[GitHub Actions: The Ubuntu 18.04 Actions runner image is being deprecated and will be removed by 12/1/22](https://github.blog/changelog/2022-08-09-github-actions-the-ubuntu-18-04-actions-runner-image-is-being-deprecated-and-will-be-removed-by-12-1-22/)



- Related issues

___
### Bugfix
- Description

- How to fix?

___
### New feature or improvement
- Describe the details and related test reports.

- Source branch

- Related commits and pull requests

- Target branch
